### PR TITLE
Using base node functionality instead of express methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,12 +123,21 @@ class MetricsMiddleware {
 
   metricsRoute(req, res) {
     if (req.headers['x-forwarded-for']) {
-      return res.sendStatus(404);
+      res.writeHead(404, {
+        'Content-Type': 'text/plain'
+      });
+      return res.end('Not Found');
     }
-    res.type('text');
-    return res.send(promClient.register.metrics());
+    if (req.headers['accept'].includes("text")) {
+      res.setHeader('content-type', 'text/plain');
+      return res.end(promClient.register.metrics())
+    }
+    else {
+      res.setHeader('content-type', 'text/json');
+      return res.end(JSON.stringify(promClient.register.getMetricsAsJSON()))
+    }
   }
-
+  
   trackDuration(req, res, next) {
     if (
       this.options.excludeRoutes &&

--- a/index.js
+++ b/index.js
@@ -124,20 +124,18 @@ class MetricsMiddleware {
   metricsRoute(req, res) {
     if (req.headers['x-forwarded-for']) {
       res.writeHead(404, {
-        'Content-Type': 'text/plain'
+        'Content-Type': 'text/plain',
       });
       return res.end('Not Found');
     }
-    if (req.headers['accept'].includes("text")) {
-      res.setHeader('content-type', 'text/plain');
-      return res.end(promClient.register.metrics())
+    if (req.headers.accept && req.headers.accept.includes('text')) {
+      res.setHeader('Content-Type', 'text/plain');
+      return res.end(promClient.register.metrics());
     }
-    else {
-      res.setHeader('content-type', 'text/json');
-      return res.end(JSON.stringify(promClient.register.getMetricsAsJSON()))
-    }
+    res.setHeader('Content-Type', 'application/json');
+    return res.end(JSON.stringify(promClient.register.getMetricsAsJSON()));
   }
-  
+
   trackDuration(req, res, next) {
     if (
       this.options.excludeRoutes &&

--- a/index.js
+++ b/index.js
@@ -128,12 +128,8 @@ class MetricsMiddleware {
       });
       return res.end('Not Found');
     }
-    if (req.headers.accept && req.headers.accept.includes('text')) {
-      res.setHeader('Content-Type', 'text/plain');
-      return res.end(promClient.register.metrics());
-    }
-    res.setHeader('Content-Type', 'application/json');
-    return res.end(JSON.stringify(promClient.register.getMetricsAsJSON()));
+    res.setHeader('Content-Type', 'text/plain');
+    return res.end(promClient.register.metrics());
   }
 
   trackDuration(req, res, next) {


### PR DESCRIPTION
Change to using base Node request and response methods instead of express ones.

This is to enable support of other frameworks (Koa)

Using koa-connect the function will be called with just the base `req` and `res` objects from vanilla node, so only methods on them should be used.

Also enabled JSON metrics if not accepting "text""

This is related to #8 