### PR TITLE
Updating to support summary sliding windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ constructor.
 |--------|---------|------|
 | `timeBuckets` | `[ 0.01, 0.1, 0.5, 1, 5 ]` |  the buckets to assign to duration histogram (in seconds) |
 | `quantileBuckets` | `[ 0.1, 0.5, 0.95, 0.99 ]` |  the quantiles to assign to duration summary (0.0 - 1.0) |
+| `quantileMaxAge` | `600` | configures sliding time window for summary (in seconds) |
+| `quantileAgeBuckets` | `5` | configures number of sliding time window buckets for summary |
 | `includeError` | `false` | whether or not to include presence of an unhandled error as a label |
 | `includePath` | `true` |  whether or not to include normalized URL path as a metric label - see [about `includePath`](#about-includepath) below |
 | `normalizePath` | |  a `function(req)` - generates path values from the express `req` object |

--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ class MetricsMiddleware {
    * @type {object}
    * @property {number[]} timeBuckets - the buckets to assign to duration histogram (in seconds)
    * @property {number[]} quantileBuckets - the quantiles to assign to duration summary (0.0 - 1.0)
+   * @property {number} quantileMaxAge configures sliding time window for summary (in seconds)
+   * @property {number} quantileAgeBuckets configures number of sliding time window buckets for summary
    * @property {string[]} paramIgnores - array of params _not_ to replace
    * @property {boolean} includeError - whether or not to include presence of an unhandled error as a label - defaults to false
    * @property {boolean} includePath - whether or not to include the URL path as a metric label - defaults to true
@@ -47,6 +49,8 @@ class MetricsMiddleware {
     _.defaults(options, defaultOpts, {
       normalizePath: this.normalizePath.bind(this),
       formatStatusCode: this.normalizeStatusCode.bind(this),
+      quantileMaxAge: 600,
+      quantileAgeBuckets: 5,
     });
     this.options = options;
     this.router = express.Router();
@@ -105,6 +109,8 @@ class MetricsMiddleware {
         help: `duration summary of http responses labeled with: ${labelNames.join(', ')}`,
         labelNames,
         percentiles: this.options.quantileBuckets,
+        maxAgeSeconds: this.options.quantileMaxAge,
+        ageBuckets: this.options.quantileAgeBuckets,
       }));
     }
     if (this.options.enableDurationHistogram) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -159,7 +158,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2255,8 +2253,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2277,14 +2274,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2299,20 +2294,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2429,8 +2421,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2442,7 +2433,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2457,7 +2447,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2465,14 +2454,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2491,7 +2478,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2572,8 +2558,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2585,7 +2570,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2671,8 +2655,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2708,7 +2691,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2728,7 +2710,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2772,14 +2753,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3839,8 +3818,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.3",
@@ -4227,7 +4205,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -5410,8 +5387,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",


### PR DESCRIPTION
`prom-client` now supports setting sliding windows. This sets a reasonable default for the HTTP quantile, so that it doesn't look so flat all the time!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>