### PR TITLE
Require Node.js v10 and update codeclimate reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,19 +3,13 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8
+      - image: qlik/node-build
     working_directory: ~/http-metrics-middleware
     steps:
       - checkout
-      - run:
-          name: greenkeeper-lockfile - Update
-          command: |
-            sudo npm install -g greenkeeper-lockfile@1
-            greenkeeper-lockfile-update
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run: npm install --no-save
-      - run: greenkeeper-lockfile-upload
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:
@@ -32,4 +26,9 @@ jobs:
               npm version $VER --no-git-tag-version
             fi
       - run: npm run lint
-      - run: npm run test:codeclimate
+      - run:
+          name: Unit tests
+          command: |
+            cc-test-reporter before-build
+            npm test
+            cc-test-reporter after-build -t lcov --exit-code $?

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Express middleware with useful prometheus metrics.
 
 This wraps [prom-client][], and adds some default metrics.
 
+_*Note:* As of v1.2.0, this module requires Node.js v10 or above._
+
 ## Contributing
 
 Contributions are welcome and encouraged! Please follow the instructions in [CONTRIBUTING.md](.github/CONTRIBUTING.md).

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "author": "QlikTech International AB",
   "license": "MIT",
   "main": "index.js",
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "scripts": {
     "test": "npm run lint && aw --babel.enable false --testExt '*_test.js' --nyc.sourceMap true --nyc.instrumenter './lib/instrumenters/istanbul' --coverage",
-    "test:codeclimate": "npm test && cat coverage/lcov.info | codeclimate-test-reporter",
     "lint": "eslint .",
     "lint-fix": "eslint --fix ."
   },
@@ -36,7 +38,6 @@
   },
   "devDependencies": {
     "@after-work.js/aw": "6.0.11",
-    "codeclimate-test-reporter": "0.5.1",
     "eslint": "6.8.0",
     "eslint-config-airbnb-base": "14.0.0",
     "eslint-plugin-import": "2.20.1",


### PR DESCRIPTION
Since `prom-client` v12.0.0, only Node.js 10 and above are supported. 6/8 are long obsolete, so this should be safe and unsurprising.

Also fixed codeclimate reporting (Fixes #54 and fixes #55)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>
