### PR TITLE
breaking: remove buildTime label from build_info metric for reproducible builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,30 +63,20 @@ class MetricsMiddleware {
    * @param {string} ns - the namespace for the metric - usually the name of the service
    * @param {string} version - the service's version
    * @param {string} revision - the git SHA hash for the running code (usually short-SHA)
-   * @param {string} buildTime - the build timestamp for the running code
    */
-  initBuildInfo(ns, version, revision, buildTime) {
+  initBuildInfo(ns, version, revision) {
     if (!ns) {
       throw new Error('namespace (ns) must be provided for build_info metric!');
     }
     const buildInfo = new promClient.Gauge({
       name: `${ns}_build_info`,
       help: `A metric with a constant 1 value labeled by version, revision, platform, nodeVersion, os from which ${ns} was built`,
-      labelNames: [
-        'version',
-        'revision',
-        'buildTime',
-        'platform',
-        'nodeVersion',
-        'os',
-        'osRelease',
-      ],
+      labelNames: ['version', 'revision', 'platform', 'nodeVersion', 'os', 'osRelease'],
     });
     buildInfo.set(
       {
         version,
         revision,
-        buildTime,
         platform: process.release.name,
         nodeVersion: process.version,
         os: process.platform,

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -110,13 +110,11 @@ describe('MetricsMiddleware', () => {
       const ns = 'foo';
       const version = '1.2.3';
       const revision = 'abcd1234';
-      const buildTime = '2017-07-07T07:07:07.007Z';
-      const m = metrics.initBuildInfo(ns, version, revision, buildTime);
+      const m = metrics.initBuildInfo(ns, version, revision);
       m.name.should.eql('foo_build_info');
       m.hashMap[Object.keys(m.hashMap)[0]].labels.should.eql({
         version,
         revision,
-        buildTime,
         nodeVersion: process.version,
         os: process.platform,
         platform: 'node',


### PR DESCRIPTION
Removes the `buildTime` label from the `*_build_info` metric created by `initBuildInfo`. The reason for this is that it further encourages [reproducible builds](https://reproducible-builds.org/). The revision (Git commit hash) should therefore be enough to determine what exact code is actually running.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>