### PR TITLE
Drop support for obsolete json output format

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const accepts = require('accepts');
 const express = require('express');
 const promClient = require('prom-client');
 const UrlValueParser = require('url-value-parser');
@@ -130,22 +129,11 @@ class MetricsMiddleware {
 
   metricsRoute(req, res) {
     if (req.headers['x-forwarded-for']) {
-      res.writeHead(404, {
-        'Content-Type': 'text/plain',
-      });
+      res.writeHead(404);
       return res.end('Not Found');
     }
     res.statusCode = 200;
-    const accept = accepts(req);
-    switch (accept.type(['text', 'json'])) {
-      case 'json':
-        res.setHeader('Content-Type', 'application/json');
-        return res.end(JSON.stringify(promClient.register.getMetricsAsJSON()));
-      case 'text':
-      default:
-        res.setHeader('Content-Type', 'text/plain');
-        return res.end(promClient.register.metrics());
-    }
+    return res.end(promClient.register.metrics());
   }
 
   trackDuration(req, res, next) {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -339,15 +339,7 @@ describe('MetricsMiddleware', () => {
       resMock.verify();
     });
 
-    it('returns the content-type with highest q weight', () => {
-      resMock.expects('setHeader').withArgs('Content-Type', 'application/json');
-      resMock.expects('end');
-      metrics.metricsRoute({ headers: { accept: 'text/plain;q=0.80,application/json;q=0.9' } }, res);
-      resMock.verify();
-    });
-
     it('registers metrics', () => {
-      resMock.expects('setHeader').withArgs('Content-Type', 'text/plain');
       registerMock.expects('metrics').returns('foo');
       resMock.expects('end').withArgs('foo');
 


### PR DESCRIPTION
The JSON output format has been obsolete for a very long time. Time to drop it.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>
