### PR TITLE
Package dependencies v2.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "http-metrics-middleware",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "http-metrics-middleware",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "accepts": "1.3.8",
@@ -597,9 +597,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -6811,9 +6811,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -12660,9 +12660,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
           "dev": true
         },
         "semver": {
@@ -17427,9 +17427,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-metrics-middleware",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Express middleware for adding common prometheus metrics",
   "author": "QlikTech International AB",
   "license": "MIT",


### PR DESCRIPTION
Update package dependencies for 2.1.3

Signed-off-by: Masaru Hoshi <masaru.hoshi@qlik.com>


```bash

up to date, audited 1044 packages in 15s

104 packages are looking for funding
  run `npm fund` for details

# npm audit report

express  <=4.17.2 || 5.0.0-alpha.1 - 5.0.0-alpha.8
Severity: high
qs vulnerable to Prototype Pollution - https://github.com/advisories/GHSA-hrpp-h998-j3pp
Depends on vulnerable versions of body-parser
Depends on vulnerable versions of qs
No fix available
node_modules/@after-work.js/server/node_modules/express
  @after-work.js/server  5.1.2 || >=6.0.0-dev.20181219.0
  Depends on vulnerable versions of @after-work.js/transform-middleware
  Depends on vulnerable versions of @after-work.js/utils
  Depends on vulnerable versions of express
  node_modules/@after-work.js/server
    @after-work.js/cdp  5.1.2 || >=6.0.0-dev.20181219.0
    Depends on vulnerable versions of @after-work.js/interactive-plugin
    Depends on vulnerable versions of @after-work.js/server
    Depends on vulnerable versions of @after-work.js/transform
    Depends on vulnerable versions of @after-work.js/utils
    Depends on vulnerable versions of @after-work.js/watch-plugin
    node_modules/@after-work.js/cdp
      @after-work.js/aw  *
      Depends on vulnerable versions of @after-work.js/cdp
      Depends on vulnerable versions of @after-work.js/cli
      Depends on vulnerable versions of @after-work.js/node
      Depends on vulnerable versions of @after-work.js/protractor
      Depends on vulnerable versions of @after-work.js/puppeteer
      Depends on vulnerable versions of @after-work.js/serve
      node_modules/@after-work.js/aw
    @after-work.js/protractor  *
    Depends on vulnerable versions of @after-work.js/preset-plugin
    Depends on vulnerable versions of @after-work.js/register
    Depends on vulnerable versions of @after-work.js/server
    Depends on vulnerable versions of @after-work.js/utils
    Depends on vulnerable versions of handlebars
    Depends on vulnerable versions of highlight.js
    Depends on vulnerable versions of mocha
    Depends on vulnerable versions of moment
    node_modules/@after-work.js/protractor
    @after-work.js/puppeteer  *
    Depends on vulnerable versions of @after-work.js/interactive-plugin
    Depends on vulnerable versions of @after-work.js/node
    Depends on vulnerable versions of @after-work.js/preset-plugin
    Depends on vulnerable versions of @after-work.js/register
    Depends on vulnerable versions of @after-work.js/server
    Depends on vulnerable versions of @after-work.js/utils
    Depends on vulnerable versions of @after-work.js/watch-plugin
    node_modules/@after-work.js/puppeteer
    @after-work.js/serve  >=6.0.0-dev.20181219.0
    Depends on vulnerable versions of @after-work.js/server
    node_modules/@after-work.js/serve

flat  <5.0.1
Severity: moderate
flat vulnerable to Prototype Pollution - https://github.com/advisories/GHSA-2j2x-2gpw-g8fm
fix available via `npm audit fix`
node_modules/flat
  yargs-unparser  <=1.6.3
  Depends on vulnerable versions of flat
  node_modules/yargs-unparser
    mocha  5.1.0 - 9.2.1
    Depends on vulnerable versions of minimatch
    Depends on vulnerable versions of yargs-unparser
    node_modules/mocha

handlebars  <=4.7.6
Severity: critical
Prototype Pollution in handlebars - https://github.com/advisories/GHSA-765h-qjxv-5f44
Remote code execution in handlebars when compiling templates - https://github.com/advisories/GHSA-f2jv-r9rf-7988
No fix available
node_modules/handlebars

highlight.js  9.0.0 - 10.4.0
Severity: moderate
ReDOS vulnerabities: multiple grammars - https://github.com/advisories/GHSA-7wwv-vh3v-89cq
fix available via `npm audit fix`
node_modules/highlight.js

minimatch  <3.0.5
Severity: high
minimatch ReDoS vulnerability - https://github.com/advisories/GHSA-f8q6-p94x-37v3
No fix available
node_modules/minimatch
  @after-work.js/register  *
  Depends on vulnerable versions of @after-work.js/transform
  Depends on vulnerable versions of @after-work.js/utils
  Depends on vulnerable versions of minimatch
  node_modules/@after-work.js/register
    @after-work.js/node  *
    Depends on vulnerable versions of @after-work.js/interactive-plugin
    Depends on vulnerable versions of @after-work.js/preset-plugin
    Depends on vulnerable versions of @after-work.js/register
    Depends on vulnerable versions of @after-work.js/transform
    Depends on vulnerable versions of @after-work.js/utils
    Depends on vulnerable versions of @after-work.js/watch-plugin
    Depends on vulnerable versions of mocha
    node_modules/@after-work.js/node
  @after-work.js/utils  >=5.1.2
  Depends on vulnerable versions of minimatch
  node_modules/@after-work.js/utils
    @after-work.js/chai-plugin-screenshot  >=5.1.2
    Depends on vulnerable versions of @after-work.js/utils
    node_modules/@after-work.js/chai-plugin-screenshot
    @after-work.js/chai-plugin-snapshot  >=5.1.2
    Depends on vulnerable versions of @after-work.js/transform
    Depends on vulnerable versions of @after-work.js/utils
    node_modules/@after-work.js/chai-plugin-snapshot
    @after-work.js/cli  5.1.2 || >=6.0.0-dev.20181219.0
    Depends on vulnerable versions of @after-work.js/chai-plugin-screenshot
    Depends on vulnerable versions of @after-work.js/chai-plugin-snapshot
    Depends on vulnerable versions of @after-work.js/interactive-plugin
    Depends on vulnerable versions of @after-work.js/utils
    node_modules/@after-work.js/cli
    @after-work.js/interactive-plugin  *
    Depends on vulnerable versions of @after-work.js/utils
    node_modules/@after-work.js/interactive-plugin
    @after-work.js/preset-plugin  *
    Depends on vulnerable versions of @after-work.js/chai-plugin-screenshot
    Depends on vulnerable versions of @after-work.js/chai-plugin-snapshot
    Depends on vulnerable versions of @after-work.js/interactive-plugin
    Depends on vulnerable versions of @after-work.js/utils
    node_modules/@after-work.js/preset-plugin
    @after-work.js/transform  >=5.1.2
    Depends on vulnerable versions of @after-work.js/utils
    node_modules/@after-work.js/transform
    @after-work.js/transform-middleware  >=5.1.2
    Depends on vulnerable versions of @after-work.js/transform
    Depends on vulnerable versions of @after-work.js/utils
    node_modules/@after-work.js/transform-middleware
    @after-work.js/watch-plugin  *
    Depends on vulnerable versions of @after-work.js/utils
    node_modules/@after-work.js/watch-plugin

moment  <=2.29.3
Severity: high
Path Traversal: 'dir/../../filename' in moment.locale - https://github.com/advisories/GHSA-8hfj-j24r-96c4
Moment.js vulnerable to Inefficient Regular Expression Complexity - https://github.com/advisories/GHSA-wc69-rhjr-hc9g
fix available via `npm audit fix`
node_modules/moment

qs  6.7.0 - 6.7.2
Severity: high
qs vulnerable to Prototype Pollution - https://github.com/advisories/GHSA-hrpp-h998-j3pp
No fix available
node_modules/@after-work.js/server/node_modules/qs
  body-parser  1.19.0
  Depends on vulnerable versions of qs
  node_modules/@after-work.js/server/node_modules/body-parser

27 vulnerabilities (3 moderate, 21 high, 3 critical)

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.
```