### PR TITLE
Use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/qlik-oss/http-metrics-middleware.git"
+    "url": "git+https://github.com/qlik-oss/http-metrics-middleware.git"
   },
   "keywords": [
     "express",


### PR DESCRIPTION
### Status

- [x] Waiting for code review

### Information

- [ ] Contains breaking changes
- [ ] Contains documentation
- [ ] Contains test

### Summary

- Update the npm `repository.url` metadata to use the public HTTPS GitHub URL instead of the SSH-only URL.
- Leave runtime code, dependencies, package entry points, bugs metadata, homepage, license, and package contents unchanged.

### Verification

- `node -e '...'` package metadata assertion
- `git diff --check`
- `pnpm install --ignore-scripts --lockfile=false --config.auto-install-peers=false --config.strict-peer-dependencies=false`
- `pnpm exec eslint .`
- `NODE_ENV=test pnpm exec mocha --exit -- './test/**/*.js'` (32 passing)
- `pnpm pack --dry-run`
